### PR TITLE
Update circle-progress.component.ts

### DIFF
--- a/src/circle-progress.component.ts
+++ b/src/circle-progress.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewChild, OnChanges, Input, Output, EventEmitter } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable ';
 
 export interface CircleProgressOptionsInterface {
   class?: string;


### PR DESCRIPTION
I think you shouldn't import from 'rxjs' or 'rxjs/Rx' since either import will import the whole of rxjs which will dramatically increase the size of your bundle.