### PR TITLE
Update README with separate installation instruction for angular 5 and 6

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,14 +8,26 @@
 
 ## About
 
-It is a simple circle progress component created for Angular 4 based only on SVG graphics and has various of options to customize it.
+It is a simple circle progress component created for [angular](https://angular.io) based only on SVG graphics and has various of options to customize it.
 
 ## Installation
 
 To install this library, run:
 
-```bash
+```
+bash
+```
+
+### Angular 6 projects
+
+```
 $ npm install ng-circle-progress --save
+```
+
+### Angular 5 projects
+
+```
+$ npm install ng-circle-progress@1.1.0 --save
 ```
 
 Once you have installed it, you can import it in any Angular application,
@@ -135,7 +147,7 @@ formatSubtitle = (percent: number) : string => {
 
 ```
 
-## Development
+## Development (needs Angular 6)
 
 To generate all `*.js`, `*.d.ts` and `*.metadata.json` files:
 


### PR DESCRIPTION
The recently released version of the library  (1.1.1) is not compatible with angular versions below 6.  Update README to let users know which version to use if they are on older angular.  