### PR TITLE
Remove unnecessary dependency on rxjs-compat

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -25,7 +25,6 @@
   "peerDependencies": {
     "@angular/core": ">=4.0.0",
     "rxjs": "^6.2.1",
-    "rxjs-compat": "^6.2.1",
     "zone.js": "^0.8.4"
   }
 }


### PR DESCRIPTION
Since the library code uses rxjs-6, rxjs-compat can be removed.