### PR TITLE
fix: remove peer dependencies on rxjs and zone.js

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -23,8 +23,6 @@
   "module": "ng-circle-progress.js",
   "typings": "ng-circle-progress.d.ts",
   "peerDependencies": {
-    "@angular/core": ">=4.0.0",
-    "rxjs": "^6.2.1",
-    "zone.js": "^0.8.4"
+    "@angular/core": ">=4.0.0"
   }
 }


### PR DESCRIPTION
When attempting to try the angular 8 RC I got this error from `ng update`:
```
Package "ng-circle-progress" has an incompatible peer dependency to "zone.js" (requires "^0.8.4", would install "0.9.0").
```

It's safe to remove the peer dependency all together, as ` "@angular/core": ">=4.0.0"` is already present and angular itself has a peer dependency on rxjs and zone.js