### PR TITLE
Adds the module with providers generic for Angular 9.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export * from './circle-progress.component';
   ]
 })
 export class NgCircleProgressModule {
-  static forRoot(options: CircleProgressOptionsInterface = {}): ModuleWithProviders {
+  static forRoot(options: CircleProgressOptionsInterface = {}): ModuleWithProviders<NgCircleProgressModule> {
     return {
       ngModule: NgCircleProgressModule,
       providers: [


### PR DESCRIPTION
## Issue:
This PR addresses the issue of the ModuleWithProviders generic no longer being optional in Angular 9.

https://github.com/bootsoon/ng-circle-progress/issues/116

